### PR TITLE
Windows bash scripts fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-TraktForVLC [![Travis Build Status](https://travis-ci.org/XaF/TraktForVLC.svg?branch=master)](https://travis-ci.org/XaF/TraktForVLC) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/e1ie51bwhbki60ns/branch/master?svg=true)](https://ci.appveyor.com/project/XaF/traktforvlc/branch/master)
+﻿TraktForVLC [![Travis Build Status](https://travis-ci.org/XaF/TraktForVLC.svg?branch=master)](https://travis-ci.org/XaF/TraktForVLC) [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/e1ie51bwhbki60ns/branch/master?svg=true)](https://ci.appveyor.com/project/XaF/traktforvlc/branch/master)
 ===========
 
 ## Table of Contents
@@ -157,7 +157,7 @@ concerned, and other options needed before running the ```set_registry_keys.bat`
 ```batch
 :::: Configuration to set the registry keys
 :: Set the full path to the VLC exe file on your computer
-set vlc_path=C:\your\path\to\VideoLAN\VLC\vlc.exe
+set "vlc_path="C:\your\path\to\VideoLAN\VLC\vlc.exe""
 
 :: Set the IP address VLC will listen to (default: localhost)
 set ip=localhost
@@ -316,4 +316,3 @@ available in your ```logs/``` directory.
 [VLC]: https://videolan.org/
 [GPLv2]: https://www.gnu.org/licenses/gpl-2.0.html
 [pin]: https://trakt.tv/pin/2498
-

--- a/windows_batch/config.bat.default
+++ b/windows_batch/config.bat.default
@@ -2,7 +2,7 @@
 ::
 :: Config file for the TraktForVLC batch script
 ::
-:: Copyright (C) 2015      RaphaÃ«l Beamonte <raphael.beamonte@gmail.com>
+:: Copyright (C) 2015      Raphaël Beamonte <raphael.beamonte@gmail.com>
 ::
 :: This file is part of TraktForVLC.  TraktForVLC is free software: you can
 :: redistribute it and/or modify it under the terms of the GNU General Public
@@ -41,7 +41,7 @@ set tfv_pidfile=C:\your\path\to\TraktForVLC\TraktForVLC.pid
 
 :::: Configuration to set the registry keys
 :: Set the full path to the VLC exe file on your computer
-set vlc_path=C:\your\path\to\VideoLAN\VLC\vlc.exe
+set "vlc_path="C:\your\path\to\VideoLAN\VLC\vlc.exe""
 
 :: Set the IP address VLC will listen to (default: localhost)
 set ip=localhost

--- a/windows_batch/restart_process.bat
+++ b/windows_batch/restart_process.bat
@@ -3,7 +3,7 @@
 :: Restart TraktForVLC process, you need to edit config.bat before
 ::
 :: Copyright (C) 2013      Damien Battistella <wifsimster@gmail.com>
-:: Copyright (C) 2015      RaphaÃ«l Beamonte <raphael.beamonte@gmail.com>
+:: Copyright (C) 2015      Raphaël Beamonte <raphael.beamonte@gmail.com>
 ::
 :: This file is part of TraktForVLC.  TraktForVLC is free software: you can
 :: redistribute it and/or modify it under the terms of the GNU General Public

--- a/windows_batch/set_registry_keys.bat
+++ b/windows_batch/set_registry_keys.bat
@@ -3,7 +3,7 @@
 :: Edit registry keys for VLC. Add needed options to launch extraintf.
 ::
 :: Copyright (C) 2013      Damien Battistella <wifsimster@gmail.com>
-:: Copyright (C) 2015      RaphaÃ«l Beamonte <raphael.beamonte@gmail.com>
+:: Copyright (C) 2015      Raphaël Beamonte <raphael.beamonte@gmail.com>
 ::
 :: This file is part of TraktForVLC.  TraktForVLC is free software: you can
 :: redistribute it and/or modify it under the terms of the GNU General Public
@@ -20,6 +20,7 @@
 :: or see <http://www.gnu.org/licenses/>.
 
 @echo off
+setlocal EnableDelayedExpansion
 
 :: Change current directory to the directory where we have out batch file
 cd /D %~dp0
@@ -35,10 +36,12 @@ echo VLC configuration : %ip%:%port%
 
 echo Editing your registry keys for formats "%formats%"
 
+set "vlc_path=!vlc_path:"=\"!"
+
 FOR %%G IN (%formats%) DO (
-	REG ADD "HKCR\VLC.%%G\shell\AddToPlaylistVLC\command" /ve /t REG_SZ /d "\"%vlc_path%\" %vlc_opts% --started-from-file --playlist-enqueue \"%%1\"" /f >NUL
-	REG ADD "HKCR\VLC.%%G\shell\Open\command" /ve /t REG_SZ /d "\"%vlc_path%\" %vlc_opts% --started-from-file \"%%1\"" /f >NUL
-	REG ADD "HKCR\VLC.%%G\shell\PlayWithVLC\command" /ve /t REG_SZ /d "\"%vlc_path%\" %vlc_opts% --started-from-file --no-playlist-enqueue \"%%1\"" /f >NUL
+	REG ADD "HKCR\VLC.%%G\shell\AddToPlaylistVLC\command" /ve /t REG_SZ /d "!vlc_path! %vlc_opts% --started-from-file --playlist-enqueue \"%%1\"" /f >NUL
+	REG ADD "HKCR\VLC.%%G\shell\Open\command" /ve /t REG_SZ /d "!vlc_path! %vlc_opts% --started-from-file \"%%1\"" /f >NUL
+	REG ADD "HKCR\VLC.%%G\shell\PlayWithVLC\command" /ve /t REG_SZ /d "!vlc_path! %vlc_opts% --started-from-file --no-playlist-enqueue \"%%1\"" /f >NUL
 )
 
 echo Registry keys modified, thanks for using !

--- a/windows_batch/start_debug_process.bat
+++ b/windows_batch/start_debug_process.bat
@@ -2,7 +2,7 @@
 ::
 :: Start TraktForVLC, you can use this batch as a schedule task on Windows
 ::
-:: Copyright (C) 2015      RaphaÃ«l Beamonte <raphael.beamonte@gmail.com>
+:: Copyright (C) 2015      Raphaël Beamonte <raphael.beamonte@gmail.com>
 ::
 :: This file is part of TraktForVLC.  TraktForVLC is free software: you can
 :: redistribute it and/or modify it under the terms of the GNU General Public

--- a/windows_batch/start_process.bat
+++ b/windows_batch/start_process.bat
@@ -3,7 +3,7 @@
 :: Start TraktForVLC, you can use this batch as a schedule task on Windows
 ::
 :: Copyright (C) 2013      Damien Battistella <wifsimster@gmail.com>
-:: Copyright (C) 2015      RaphaÃ«l Beamonte <raphael.beamonte@gmail.com>
+:: Copyright (C) 2015      Raphaël Beamonte <raphael.beamonte@gmail.com>
 ::
 :: This file is part of TraktForVLC.  TraktForVLC is free software: you can
 :: redistribute it and/or modify it under the terms of the GNU General Public

--- a/windows_batch/stop_process.bat
+++ b/windows_batch/stop_process.bat
@@ -2,7 +2,7 @@
 ::
 :: Stop TraktForVLC
 ::
-:: Copyright (C) 2015      RaphaÃ«l Beamonte <raphael.beamonte@gmail.com>
+:: Copyright (C) 2015      Raphaël Beamonte <raphael.beamonte@gmail.com>
 ::
 :: This file is part of TraktForVLC.  TraktForVLC is free software: you can
 :: redistribute it and/or modify it under the terms of the GNU General Public


### PR DESCRIPTION
- The "set_registry_keys.bat" was malfunctioning, it worked well only if VLC 64 bit is used, because under windows the last parenthesis in Program Files (x86) was causing the FOR loop to quit before executing the lines of code inside. To fix this I've used DelayedExpansion so now the script should work with VLC in any path. To make the script work I've also edited the "config.bat.default" file.

- All batchscripts were almost unreadable inside Windows default text editor, and even if the first line was commented the command prompt was giving a strange error, so I've converted all the scripts from UTF-8 and Unix EOL to ANSI PC EOL so this fixed the errors and make them readable with te correct CR and LFs.

- Edited README.md to reflect changes made in batch scripts