### PR TITLE
Fix Python3 utf-8 problem

### DIFF
--- a/TraktForVLC.py
+++ b/TraktForVLC.py
@@ -442,9 +442,9 @@ class TraktForVLC(object):
         currentFilePath = vlc.get_filename()
 
         if self.USE_FILENAME:
-            currentFileName = currentFilePath
+            currentFileName = currentFilePath.decode('utf-8')
         else:
-            currentFileName = vlc.get_title()
+            currentFileName = vlc.get_title().decode('utf-8')
         self.vlcTime = int(vlc.get_time())
 
         # Parse the filename to verify if it comes from a stream


### PR DESCRIPTION
When I tried to use this script, I got the following error:
```
...
  File "TraktForVLC.py", line 462, in main
    currentFileName = unquote(currentFileName)
  File "/usr/lib/python3.6/urllib/parse.py", line 608, in unquote
    if '%' not in string:
TypeError: a bytes-like object is required, not 'str'
```
I didn't dig the code much but it appends _b'_ prefix to filename. According to here[1]:
> A prefix of 'b' or 'B' is ignored in Python 2; it indicates that the literal should become a bytes literal in Python 3 (e.g. when code is automatically converted with 2to3). A 'u' or 'b' prefix may be followed by an 'r' prefix.

It interprets the file name as bytes. I changed two lines to avoid that but I'm not sure that it's the right way of fixing this however it just works. I couldn't test it with python2, my workspace doesn't allow me to do that at the moment, but I will report if it works or not as soon as possible.

[1]: https://docs.python.org/2/reference/lexical_analysis.html#string-literals
