### PR TITLE
TraktForVLC.py: fix TVDB keys

### DIFF
--- a/TraktForVLC.py
+++ b/TraktForVLC.py
@@ -608,16 +608,17 @@ class TraktForVLC(object):
 
                 try:
                     episode = series[int(seasonNumber)][int(currentEpisode)]
+
                     return self.set_video(
                         True,
                         series['seriesname'],
-                        series['firstaired'],
-                        episode['imdb_id'],
+                        series['firstAired'],
+                        episode['imdbId'],
                         duration,
                         percentage,
                         episode['seasonnumber'],
                         episode['episodenumber'],
-                        series['imdb_id'])
+                        series['imdbId'])
                 except:
                     self.log.warning("Episode : No valid episode found !")
                     self.log.debug("get_TV::Here's to help debug",


### PR DESCRIPTION
Looks like some of the TVDB's API's keys have changed: 
https://api.thetvdb.com/swagger#!/Episodes/get_episodes_id
https://api.thetvdb.com/swagger#!/Series/get_series_id