### PR TITLE
Fix movies and episodes resolution for some edge cases

### DIFF
--- a/helper/commands/resolve.py
+++ b/helper/commands/resolve.py
@@ -875,7 +875,9 @@ class CommandResolve(Command):
                 m_season = m['base']['season']
                 m_ep = m['base']['episode']
                 m_year = m['base']['parentTitle']['year']
-                ids = resolve_episode_ids(m_series, m_season, m_ep, m_year)
+                m_series_imdbid = m['base']['parentTitle']['id'][7:-1]
+                ids = resolve_episode_ids(m_series, m_season, m_ep, m_year,
+                                          m_series_imdbid)
             else:
                 m_movie = m['base']['title']
                 m_year = m['base']['year']

--- a/trakt.lua
+++ b/trakt.lua
@@ -2414,7 +2414,12 @@ function process_scrobble_ready()
                             table.insert(command, imdbinfo.parentTitle.title)
                             table.insert(command, tostring(imdbinfo.season))
                             table.insert(command, tostring(imdbinfo.episode))
-                            table.insert(command, tostring(imdbinfo.parentTitle.year))
+                            table.insert(
+                                command,
+                                tostring(imdbinfo.parentTitle.year))
+                            table.insert(
+                                command,
+                                string.sub(imdbinfo.parentTitle.id, 8, -2))
                         else
                             table.insert(command, '--movie')
                             table.insert(command, imdbinfo.title)


### PR DESCRIPTION
Movie resolution was failing when the text search for a movie was reaching a point where the mean proximity added to the standard deviation of the proximity for the movies was over 100 (as it was compared to proximities in percent).

Episode resolution was failing when the IMDB ID is not sufficient for trakt.tv (some IMDB IDs seem to be missing) and the TV show was registered with different first air date in IMDB and TheTVDB to get the extra IDs.

This fixes those, as reported in #98. 