### PR TITLE
helper: commands: resolve: fix movie resolution

### DIFF
--- a/helper/commands/resolve.py
+++ b/helper/commands/resolve.py
@@ -1006,8 +1006,9 @@ class CommandResolve(Command):
 
         # Return in the form of a list
         media['base']['imdbid'] = media['base']['id'][7:-1]
-        media['base']['parentTitle']['imdbid'] = \
-            media['base']['parentTitle']['id'][7:-1]
+        if 'parentTitle' in media['base']:
+            media['base']['parentTitle']['imdbid'] = \
+                media['base']['parentTitle']['id'][7:-1]
         media_list = [media, ]
 
         # If it was an episode, and we had more episodes in the list...


### PR DESCRIPTION
Commit f43646067521d794661b69b8a2b3aa372466d5a2 introduced a
bug by converting the imdb id returned in the URL form by
imdbpie to the imdb id alone, and doing so for the
'parentTitle' of the media, which represents a series for
a TV episode, but does not exist for a movie. This commit
fixes that behavior by checking that the 'parentTitle'
exists before applying the conversion at its level.

Fixes #119

Signed-off-by: Raphaël Beamonte <raphael.beamonte@gmail.com>