### PR TITLE
fix VLC verbose command, add MacOS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ The `trakt_config.json` file is located in your VLC configuration directory. Dep
 ## Issues
 Please use the [GitHub integrated issue tracker](https://github.com/XaF/TraktForVLC/issues) for every problem you can encounter. Please **DO NOT** use my email for issues or walkthrough.
 
-When submitting an issue, please submit a VLC logfile showing the error. You can start VLC in debug mode (`--vv` option) to obtain more thorough logs.
+When submitting an issue, please submit a VLC logfile showing the error. You can start VLC in debug mode (`-vv` option) to obtain more thorough logs.
+
+On MacOS, VLC is run from the command line in verbose mode like so:
+```
+$ /Applications/VLC.app/Contents/MacOS/VLC -vv
+```
 
 > **Please** be careful to remove any personnal information that might still be in the logfile (password, identification token, ...) before putting your file online.


### PR DESCRIPTION
Hi there, because I've been having problems with the plugin not scrobbling properly/most of the time, I recently tried to get VLC to output logs, only to find that the instruction in the README for verbose mode was (ever so slightly) off.

I've corrected this in this PR and also added info on how to start VLC from the command line on MacOS, as I had to google this because it's done differently from how other applications are run from the CLI.